### PR TITLE
docs(readme): add mini-grep entry; polish with badges/icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-# Rust Practice Projects
+# 🦀 Rust Practice Projects
+
+[![Rust 2021](https://img.shields.io/badge/rust-2021%20edition-orange?logo=rust&logoColor=white)](#)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Status: Learning](https://img.shields.io/badge/status-learning-6aa84f.svg)](#)
 
 This repository is a personal space to practice Rust by building small, focused projects. It serves as a sandbox to experiment with language features, tooling, and common patterns in command-line applications and beyond.
 
-## Projects
+## 📦 Projects
 
-- mycalc: A simple command-line calculator built with the `clap` crate for argument parsing. It showcases basic CLI structure, flags/arguments, and error handling.
-  - Path: `./mycalc`
+- 🧮 mycalc: A simple command-line calculator built with the `clap` crate for argument parsing. It showcases basic CLI structure, flags/arguments, and error handling.
+  - 📂 Path: `./mycalc`
 
-Each project will get its own dedicated README with usage details and examples over time. This top-level README stays brief and points to the individual projects.
+- 🔎 mini-grep: A tiny grep-like text searcher supporting regex, recursive search, glob filtering, line numbers, whole-word matches, ANSI color, and .gitignore awareness.
+  - 📂 Path: `./mini-grep`
 
+📘 Each project will get its own dedicated README with usage details and examples over time. This top-level README stays brief and points to the individual projects.


### PR DESCRIPTION
# Summary
Documentation update to the **root README**: add an index entry for the new **mini-grep** project and polish the page with badges/icons.  
**Docs-only; no code changes.**

**Scope/Location:** root `README.md` (links to `mini-grep/`)

---

# What’s Included
- Add **mini-grep** entry to the project index with short description and path.
- Add badges: **Rust 2021**, **MIT**, **Status: Learning**.
- Light visual polish:
  - Subtle emojis/icons on the title and project list items.
  - Consistent heading levels and spacing.
  - Minor copy edits for clarity/consistency.